### PR TITLE
fix base58 encode bug

### DIFF
--- a/multihash/codecs.py
+++ b/multihash/codecs.py
@@ -48,7 +48,7 @@ class CodecReg(metaclass=_CodecRegMeta):
         ('base64', base64.b64encode, base64.b64decode)]
     if base58:
         _common_codec_data.append(
-            ('base58', lambda s: bytes(base58.b58encode(s), 'ascii'), base58.b58decode))
+            ('base58', lambda s: bytes(base58.b58encode(s).decode(), 'ascii'), base58.b58decode))
 
     # Codec data: encoding and decoding functions (both from bytes to bytes).
     _codec = namedtuple('codec', 'encode decode')


### PR DESCRIPTION
.encode('base58') error:
"encoding without a string argument"

How to reproduce:
```
>>> import multihash
>>> mh = multihash.decode(b'\x12 \xb3\x9b\xed\xf8\x9d}\xf75G$\x84f\x97\xd6\x1b\xcev\xf9\xfdW{@{\x86-\x181\xa0tb\x88\xe2')
>>> mh.encode('base58')
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: encoding without a string argument
```

Python version: 3.6.6.
pymultihash version: 0.8.2
base58 version: 1.0.2