### PR TITLE
Fixed a TypeError in FuncReg.unregister

### DIFF
--- a/multihash/funcs.py
+++ b/multihash/funcs.py
@@ -217,7 +217,7 @@ class FuncReg(metaclass=_FuncRegMeta):
             ...
         KeyError: ('unknown hash function', 'md-5')
         """
-        if code in Func:
+        if not _is_app_specific_func(code):
             raise ValueError(
                 "only application-specific functions can be unregistered")
         # Remove mapping to function by name.


### PR DESCRIPTION
Fixed an incorrect check of the code against the values defined
in the `Func` enum. This check would trigger the following error:

TypeError: unsupported operand type(s) for 'in': 'int' and 'EnumMeta'

when checking the code.